### PR TITLE
CI: Build RISC-V 64 image with riscv64/alpine:edge

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -10,6 +10,11 @@ jobs:
     strategy:
       matrix:
         arch: [aarch64, riscv64]
+        include:
+          - arch: aarch64
+            distro: alpine_latest
+          - arch: riscv64
+            distro: alpine_edge
     env:
       ROOT_TARGET: "target"
 
@@ -25,7 +30,7 @@ jobs:
         uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{ matrix.arch }}
-          distro: alpine_latest
+          distro: ${{ matrix.distro }}
           run: |
             uname -a
             ls -l

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,10 +4,12 @@ ROOT_TARGET=$1
 
 cat /etc/os-release
 
+APK_REPO_URL=$(head -n 1 /etc/apk/repositories)
+
 apk add apk-tools-static
 apk.static \
   --arch $(uname -m) \
-  -X http://dl-cdn.alpinelinux.org/alpine/latest-stable/main/ \
+  -X $APK_REPO_URL \
   -U \
   --allow-untrusted \
   --root $ROOT_TARGET \


### PR DESCRIPTION
Current alpine stable version v3.17 does not have RISC-V 64 arch packages [1]. But, the edge version has [2].

So, build the image with the container image "riscv64/alpine:edge" as workaround. Will change back to "alpine:latest" for all architectures.

[1]: https://dl-cdn.alpinelinux.org/alpine/v3.17/main/
[2]: https://dl-cdn.alpinelinux.org/alpine/edge/main/

Fixes: https://github.com/starnight/build-image/issues/2