### PR TITLE
bootstrap: Set ttyS0 as RISC-V 64 QEMU virt's console

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -16,7 +16,16 @@ apk.static \
   --initdb add alpine-base
 
 echo "Have serial console"
-sed -i '/\#ttyS0::respawn:\/sbin\/getty -L ttyS0 115200 vt100/a\ttyAMA0::respawn:\/sbin\/getty -L 0 ttyAMA0 vt100' $ROOT_TARGET/etc/inittab
+PATTERN_STR='\#ttyS0::respawn:\/sbin\/getty -L ttyS0 115200 vt100'
+case $(uname -m) in
+  aarch64)
+    APPEND_STR='\ttyAMA0::respawn:\/sbin\/getty -L 0 ttyAMA0 vt100' ;;
+  riscv64)
+    APPEND_STR='\ttyS0::respawn:\/sbin\/getty -L ttyS0 115200 vt100' ;;
+  *)
+    APPEND_STR=''
+esac
+sed -i "/${PATTERN_STR}/a${APPEND_STR}" $ROOT_TARGET/etc/inittab
 
 echo "Deploy fstab"
 install -D data/fstab $ROOT_TARGET/etc/fstab


### PR DESCRIPTION
The kernel's dmesg shows that "ttyS0" is the console:

Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
10000000.serial: ttyS0 at MMIO 0x10000000 (irq = 1, base_baud = 230400) is a 16550A
printk: console [ttyS0] enabled