### PR TITLE
CI: Format image partitions with label information

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -93,8 +93,8 @@ jobs:
           echo "Boot: ${boot}"
           echo "Root: ${root}"
 
-          sudo mkfs.vfat -v ${boot}
-          sudo mkfs.ext4 ${root}
+          sudo mkfs.vfat -n BOOT -v ${boot}
+          sudo mkfs.ext4 -L ROOT ${root}
 
           mkdir ${{ env.ROOT_TARGET }}
           sudo mount -t ext4 ${root} ${{ env.ROOT_TARGET }}

--- a/data/fstab
+++ b/data/fstab
@@ -1,2 +1,2 @@
-/dev/vda2	/		ext4	rw,relatime	0 0
-/dev/vda1	/boot		vfat	rw,relatime	0 0
+LABEL=ROOT	/		ext4	rw,relatime	0 0
+LABEL=BOOT	/boot		vfat	rw,relatime	0 0

--- a/data/rpi/cmdline.txt
+++ b/data/rpi/cmdline.txt
@@ -1,1 +1,1 @@
-console=ttyS1,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rw rootwait loglevel=6 raid=noautodetect
+console=ttyS1,115200 console=tty1 root=LABEL=ROOT rootfstype=ext4 rw rootwait loglevel=6 raid=noautodetect


### PR DESCRIPTION
Different platforms may use different block device types. Besides, the order may be changed, too. So, set the label information for each partitions as: BOOT and ROOT. System can boot by getting root with LABEL=ROOT, and mount partitions with labels correctly.